### PR TITLE
Rewrite changes

### DIFF
--- a/run.py
+++ b/run.py
@@ -81,7 +81,7 @@ anti_duplicate_replies = {}
 
 @client.event
 async def on_message(message):
-    if message.guild.me.activity is None or message.guild.me.activity.name != config['Main']['playing']:
+    if client.channel.guild.me.activity is None or client.channel.guild.me.activity.name != config['Main']['playing']:
         await client.change_presence(activity=discord.Game(name=config['Main']['playing']))
     author = message.author
     if author == client.user:
@@ -193,7 +193,7 @@ async def on_message(message):
                     await client.channel.send('Did you forget to enter a message?')
                 else:
                     for server in client.guilds:
-                        member = server.get_member(command_name)
+                        member = server.get_member(int(command_name))
                         if member:
                             embed = discord.Embed(color=gen_color(int(command_name)), description=command_contents)
                             if config['Main']['anonymous_staff']:

--- a/run.py
+++ b/run.py
@@ -40,7 +40,6 @@ async def on_ready():
         await client.close()
     # await client.send_message(client.channel, '{0.user} is now ready.'.format(client))
     print('{0.user} is now ready.'.format(client))
-    await client.change_presence(activity=discord.Game(name=config['Main']['playing']))
     client.already_ready = True
 
 
@@ -57,6 +56,8 @@ anti_spam_check = {}
 
 @client.event
 async def on_message(message):
+    if ctx.guild.me.activity.name != config['Main']['playing']:
+        await client.change_presence(activity=discord.Game(name=config['Main']['playing']))
     author = message.author
     if author == client.user:
         return
@@ -151,5 +152,4 @@ async def on_message(message):
                             await client.channel.send('{0.mention} {1.mention} has disabled DMs or is not in a shared server.'.format(author, member))
                         break
 
-
-client.run(config['Main']['token'])
+client.run(config['Main']['token'], status=discord.Game(name=config['Main']['playing']))


### PR DESCRIPTION
This changes the entire bot to be functional in rewrite.

Also made fix game pretty much automatic (being called on every message to check if it's still consistent, if its not, it'll try fixing it).

Given how (at least from my experience) python3.7+ doesn't really support async anymore, this change should be needed at some point and given how Fedora 29 bundles 3.7 by default, I chose to rewrite the bot before python3.6 gets deprecated completely.

Specific changes for rewrite are:
- Moved change_presence() out of the on_ready() call and to the client initializer.
- Cast command arguments that are IDs to ints.
- Change `client.servers` to `client.guilds`.

The fix for change_presence is:
- At the start of the on_message() call, a check is executed to see if the Activity is either None or not matching to the set string in the config. If this is the case, a call is made to change_presence() to update the presence to the proper string.

The rewrite changes have been locally used for 2 weeks and they're pretty much fully tested, but manual testing is still advised.